### PR TITLE
Render tags on single note page

### DIFF
--- a/content/notes/dev-tips/fix-github-error-remote-end-hung-up.mdx
+++ b/content/notes/dev-tips/fix-github-error-remote-end-hung-up.mdx
@@ -2,7 +2,7 @@
 title: "Fix Github error: remote end hung up unexpectedly"
 date: "2020-08-07"
 tags:
-  - DevTips
+  - TIPS
 tech:
   - github
 ---

--- a/content/notes/dev-tips/fix-netlify-error-node-incompatible.mdx
+++ b/content/notes/dev-tips/fix-netlify-error-node-incompatible.mdx
@@ -2,7 +2,7 @@
 title: "Fix Netlify deploy error: engine node incompatible with module"
 date: "2020-08-07"
 tags:
-  - DevTips
+  - TIPS
 tech:
   - netlify-hosting
 ---

--- a/content/notes/dev-tips/gatsby-graphql-contentful-optional-image.mdx
+++ b/content/notes/dev-tips/gatsby-graphql-contentful-optional-image.mdx
@@ -2,7 +2,7 @@
 title: Set up optional image field from Contentful in Gatsby GraphQL
 date: "2020-08-08"
 tags:
-  - DevTips
+  - TIPS
 tech:
   - gatsby
   - contentful

--- a/content/notes/dev-tips/git-copy-individual-files-across-branches.mdx
+++ b/content/notes/dev-tips/git-copy-individual-files-across-branches.mdx
@@ -2,7 +2,7 @@
 title: Copy individual files or directories across branches on Github
 date: "2019-09-19"
 tags:
-  - DevTips
+  - TIPS
 tech:
   - git
 ---

--- a/content/notes/dev-tips/git-download-specific-folder-remote-repo.mdx
+++ b/content/notes/dev-tips/git-download-specific-folder-remote-repo.mdx
@@ -2,7 +2,7 @@
 title: "Download a specific folder/directory from a Github repository"
 date: "2019-07-24"
 tags:
-  - DevTips
+  - TIPS
 tech:
   - git
 ---

--- a/content/notes/dev-tips/imagemagick-batch-resize.mdx
+++ b/content/notes/dev-tips/imagemagick-batch-resize.mdx
@@ -2,7 +2,7 @@
 title: "Batch resize images in ImageMagick"
 date: "2019-09-18"
 tags:
-  - DevTips
+  - TIPS
 tech:
   - imagemagick
 ---

--- a/content/notes/dev-tips/laravel-api-post-route-basic-example.mdx
+++ b/content/notes/dev-tips/laravel-api-post-route-basic-example.mdx
@@ -2,7 +2,7 @@
 title: "Laravel API POST route basic example"
 date: "2020-07-23"
 tags:
-  - DevTips
+  - TIPS
 tech:
   - laravel
 ---

--- a/content/notes/dev-tips/laravel-blade-custom-helper.mdx
+++ b/content/notes/dev-tips/laravel-blade-custom-helper.mdx
@@ -2,7 +2,7 @@
 title: "Laravel Blade custom helper function, a basic example"
 date: "2019-09-25"
 tags:
-  - DevTips
+	- TIPS
 tech:
   - laravel
 ---

--- a/content/notes/dev-tips/next-js-browser-history-back.mdx
+++ b/content/notes/dev-tips/next-js-browser-history-back.mdx
@@ -2,7 +2,7 @@
 title: Emulate browser back behaviour with NextJS router
 date: "2019-12-03"
 tags:
-  - DevTips
+  - TIPS
 tech:
   - nextjs
 ---

--- a/content/notes/dev-tips/prefers-color-scheme-detection.mdx
+++ b/content/notes/dev-tips/prefers-color-scheme-detection.mdx
@@ -2,7 +2,7 @@
 title: Detect user’s prefers-color-scheme value
 date: "2019-12-27"
 tags:
-  - DevTips
+  - TIPS
 tech:
   - javascript
   - css

--- a/content/notes/dev-tips/slugify-encode-url-accented-characters.mdx
+++ b/content/notes/dev-tips/slugify-encode-url-accented-characters.mdx
@@ -2,7 +2,7 @@
 title: "Slugify and encode accented unicode characters in JS and PHP"
 date: "2019-09-06"
 tags:
-  - DevTips
+  - TIPS
 tech:
   - javascript
   - php

--- a/content/notes/learning-notes/graphql-adventure-club-intro.mdx
+++ b/content/notes/learning-notes/graphql-adventure-club-intro.mdx
@@ -2,7 +2,7 @@
 title: GraphQL Adventure Club at the Party-Corgi Discord
 date: "2020-08-17"
 tags:
-  - Learning Notes
+  - LEARNING_NOTES
 tech:
   - graphql
 ---

--- a/package-lock.json
+++ b/package-lock.json
@@ -2728,15 +2728,6 @@
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
       "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA="
     },
-    "camel-case": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
-      "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
-      "requires": {
-        "no-case": "^2.2.0",
-        "upper-case": "^1.1.1"
-      }
-    },
     "camelcase": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
@@ -2794,31 +2785,6 @@
             "has-flag": "^3.0.0"
           }
         }
-      }
-    },
-    "change-case": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/change-case/-/change-case-3.1.0.tgz",
-      "integrity": "sha512-2AZp7uJZbYEzRPsFoa+ijKdvp9zsrnnt6+yFokfwEpeJm0xuJDVoxiRCAaTzyJND8GJkofo2IcKWaUZ/OECVzw==",
-      "requires": {
-        "camel-case": "^3.0.0",
-        "constant-case": "^2.0.0",
-        "dot-case": "^2.1.0",
-        "header-case": "^1.0.0",
-        "is-lower-case": "^1.1.0",
-        "is-upper-case": "^1.1.0",
-        "lower-case": "^1.1.1",
-        "lower-case-first": "^1.0.0",
-        "no-case": "^2.3.2",
-        "param-case": "^2.1.0",
-        "pascal-case": "^2.0.0",
-        "path-case": "^2.1.0",
-        "sentence-case": "^2.1.0",
-        "snake-case": "^2.1.0",
-        "swap-case": "^1.1.0",
-        "title-case": "^2.1.0",
-        "upper-case": "^1.1.1",
-        "upper-case-first": "^1.1.0"
       }
     },
     "character-entities": {
@@ -3127,15 +3093,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.2.0.tgz",
       "integrity": "sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA=="
-    },
-    "constant-case": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-2.0.0.tgz",
-      "integrity": "sha1-QXV2TTidP6nI7NKRhu1gBSQ7akY=",
-      "requires": {
-        "snake-case": "^2.1.0",
-        "upper-case": "^1.1.1"
-      }
     },
     "constants-browserify": {
       "version": "1.0.0",
@@ -3745,14 +3702,6 @@
           "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.0.1.tgz",
           "integrity": "sha512-5HOHUDsYZWV8FGWN0Njbr/Rn7f/eWSQi1v7+HsUVwXgn8nWWlL64zKDkS0n8ZmQ3mlWOMuXOnR+7Nx/5tMO5AQ=="
         }
-      }
-    },
-    "dot-case": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-2.1.1.tgz",
-      "integrity": "sha1-NNzzf1Co6TwrO8qLt/uRVcfaO+4=",
-      "requires": {
-        "no-case": "^2.2.0"
       }
     },
     "dot-prop": {
@@ -4582,15 +4531,6 @@
       "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
       "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0="
     },
-    "header-case": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/header-case/-/header-case-1.0.1.tgz",
-      "integrity": "sha1-lTWXMZfBRLCWE81l0xfvGZY70C0=",
-      "requires": {
-        "no-case": "^2.2.0",
-        "upper-case": "^1.1.3"
-      }
-    },
     "hex-color-regex": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/hex-color-regex/-/hex-color-regex-1.1.0.tgz",
@@ -4879,14 +4819,6 @@
       "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz",
       "integrity": "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw=="
     },
-    "is-lower-case": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/is-lower-case/-/is-lower-case-1.1.3.tgz",
-      "integrity": "sha1-fhR75HaNxGbbO/shzGCzHmrWk5M=",
-      "requires": {
-        "lower-case": "^1.1.0"
-      }
-    },
     "is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -4937,14 +4869,6 @@
       "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
       "requires": {
         "has-symbols": "^1.0.1"
-      }
-    },
-    "is-upper-case": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/is-upper-case/-/is-upper-case-1.1.2.tgz",
-      "integrity": "sha1-jQsfp+eTOh5YSDYA7H2WYcuvdW8=",
-      "requires": {
-        "upper-case": "^1.1.0"
       }
     },
     "is-whitespace-character": {
@@ -5210,19 +5134,6 @@
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
     },
-    "lower-case": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
-      "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw="
-    },
-    "lower-case-first": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/lower-case-first/-/lower-case-first-1.0.2.tgz",
-      "integrity": "sha1-5dp8JvKacHO+AtUrrJmA5ZIq36E=",
-      "requires": {
-        "lower-case": "^1.1.2"
-      }
-    },
     "lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -5373,21 +5284,6 @@
       "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-1.1.0.tgz",
       "integrity": "sha512-jVU0Nr2B9X3MU4tSK7JP1CMkSvOj7X5l/GboG1tKRw52lLF1x2Ju92Ms9tNetCcbfX3hzlM73zYo2NKkWSfF/A=="
     },
-    "mdast-util-toc": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/mdast-util-toc/-/mdast-util-toc-5.0.3.tgz",
-      "integrity": "sha512-A3xzcgC1XFHK0+abFmbINOxjwo7Bi0Nsfp3yTgTy5JHo2q2V6YZ5BVJreDWoK3szcLlSMvHqe8WPbjY50wAkow==",
-      "dev": true,
-      "requires": {
-        "@types/mdast": "^3.0.3",
-        "@types/unist": "^2.0.3",
-        "extend": "^3.0.2",
-        "github-slugger": "^1.2.1",
-        "mdast-util-to-string": "^1.0.5",
-        "unist-util-is": "^4.0.0",
-        "unist-util-visit": "^2.0.0"
-      }
-    },
     "mdn-data": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.4.tgz",
@@ -5397,205 +5293,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
       "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4="
-    },
-    "mdx-table-of-contents": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/mdx-table-of-contents/-/mdx-table-of-contents-0.1.0.tgz",
-      "integrity": "sha512-aNhJvAkghJEKLat+THHJB9qi2bS4iBl1wNDLfwbByUZTvQ8DgLKUJ/TMEIrcWMuuks6BbsK7sp2IqLTUPnUfZQ==",
-      "requires": {
-        "@mdx-js/mdx": "^0.15.5"
-      },
-      "dependencies": {
-        "@mdx-js/mdx": {
-          "version": "0.15.7",
-          "resolved": "https://registry.npmjs.org/@mdx-js/mdx/-/mdx-0.15.7.tgz",
-          "integrity": "sha512-bWUQidQhjTRFh5nK01kW3qQLCH/aCq6VTapOZ/+WI5hL4exoRw6TgnxxmgSf/p7mmrGxIpCHmnaWXdbHSObxlg==",
-          "requires": {
-            "change-case": "^3.0.2",
-            "detab": "^2.0.0",
-            "mdast-util-to-hast": "^3.0.0",
-            "remark-parse": "^5.0.0",
-            "remark-squeeze-paragraphs": "^3.0.1",
-            "to-style": "^1.3.3",
-            "unified": "^6.1.6",
-            "unist-util-visit": "^1.3.0"
-          }
-        },
-        "is-buffer": {
-          "version": "1.1.6",
-          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-          "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
-        },
-        "is-plain-obj": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-          "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
-        },
-        "mdast-squeeze-paragraphs": {
-          "version": "3.0.5",
-          "resolved": "https://registry.npmjs.org/mdast-squeeze-paragraphs/-/mdast-squeeze-paragraphs-3.0.5.tgz",
-          "integrity": "sha512-xX6Vbe348Y/rukQlG4W3xH+7v4ZlzUbSY4HUIQCuYrF2DrkcHx584mCaFxkWoDZKNUfyLZItHC9VAqX3kIP7XA==",
-          "requires": {
-            "unist-util-remove": "^1.0.0"
-          }
-        },
-        "mdast-util-definitions": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/mdast-util-definitions/-/mdast-util-definitions-1.2.5.tgz",
-          "integrity": "sha512-CJXEdoLfiISCDc2JB6QLb79pYfI6+GcIH+W2ox9nMc7od0Pz+bovcHsiq29xAQY6ayqe/9CsK2VzkSJdg1pFYA==",
-          "requires": {
-            "unist-util-visit": "^1.0.0"
-          }
-        },
-        "mdast-util-to-hast": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-3.0.4.tgz",
-          "integrity": "sha512-/eIbly2YmyVgpJNo+bFLLMCI1XgolO/Ffowhf+pHDq3X4/V6FntC9sGQCDLM147eTS+uSXv5dRzJyFn+o0tazA==",
-          "requires": {
-            "collapse-white-space": "^1.0.0",
-            "detab": "^2.0.0",
-            "mdast-util-definitions": "^1.2.0",
-            "mdurl": "^1.0.1",
-            "trim": "0.0.1",
-            "trim-lines": "^1.0.0",
-            "unist-builder": "^1.0.1",
-            "unist-util-generated": "^1.1.0",
-            "unist-util-position": "^3.0.0",
-            "unist-util-visit": "^1.1.0",
-            "xtend": "^4.0.1"
-          }
-        },
-        "parse-entities": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.2.2.tgz",
-          "integrity": "sha512-NzfpbxW/NPrzZ/yYSoQxyqUZMZXIdCfE0OIN4ESsnptHJECoUk3FZktxNuzQf4tjt5UEopnxpYJbvYuxIFDdsg==",
-          "requires": {
-            "character-entities": "^1.0.0",
-            "character-entities-legacy": "^1.0.0",
-            "character-reference-invalid": "^1.0.0",
-            "is-alphanumerical": "^1.0.0",
-            "is-decimal": "^1.0.0",
-            "is-hexadecimal": "^1.0.0"
-          }
-        },
-        "remark-parse": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-5.0.0.tgz",
-          "integrity": "sha512-b3iXszZLH1TLoyUzrATcTQUZrwNl1rE70rVdSruJFlDaJ9z5aMkhrG43Pp68OgfHndL/ADz6V69Zow8cTQu+JA==",
-          "requires": {
-            "collapse-white-space": "^1.0.2",
-            "is-alphabetical": "^1.0.0",
-            "is-decimal": "^1.0.0",
-            "is-whitespace-character": "^1.0.0",
-            "is-word-character": "^1.0.0",
-            "markdown-escapes": "^1.0.0",
-            "parse-entities": "^1.1.0",
-            "repeat-string": "^1.5.4",
-            "state-toggle": "^1.0.0",
-            "trim": "0.0.1",
-            "trim-trailing-lines": "^1.0.0",
-            "unherit": "^1.0.4",
-            "unist-util-remove-position": "^1.0.0",
-            "vfile-location": "^2.0.0",
-            "xtend": "^4.0.1"
-          }
-        },
-        "remark-squeeze-paragraphs": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/remark-squeeze-paragraphs/-/remark-squeeze-paragraphs-3.0.4.tgz",
-          "integrity": "sha512-Wmz5Yj9q+W1oryo8BV17JrOXZgUKVcpJ2ApE2pwnoHwhFKSk4Wp2PmFNbmJMgYSqAdFwfkoe+TSYop5Fy8wMgA==",
-          "requires": {
-            "mdast-squeeze-paragraphs": "^3.0.0"
-          }
-        },
-        "unified": {
-          "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/unified/-/unified-6.2.0.tgz",
-          "integrity": "sha512-1k+KPhlVtqmG99RaTbAv/usu85fcSRu3wY8X+vnsEhIxNP5VbVIDiXnLqyKIG+UMdyTg0ZX9EI6k2AfjJkHPtA==",
-          "requires": {
-            "bail": "^1.0.0",
-            "extend": "^3.0.0",
-            "is-plain-obj": "^1.1.0",
-            "trough": "^1.0.0",
-            "vfile": "^2.0.0",
-            "x-is-string": "^0.1.0"
-          }
-        },
-        "unist-builder": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/unist-builder/-/unist-builder-1.0.4.tgz",
-          "integrity": "sha512-v6xbUPP7ILrT15fHGrNyHc1Xda8H3xVhP7/HAIotHOhVPjH5dCXA097C3Rry1Q2O+HbOLCao4hfPB+EYEjHgVg==",
-          "requires": {
-            "object-assign": "^4.1.0"
-          }
-        },
-        "unist-util-is": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-3.0.0.tgz",
-          "integrity": "sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A=="
-        },
-        "unist-util-remove": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/unist-util-remove/-/unist-util-remove-1.0.3.tgz",
-          "integrity": "sha512-mB6nCHCQK0pQffUAcCVmKgIWzG/AXs/V8qpS8K72tMPtOSCMSjDeMc5yN+Ye8rB0FhcE+JvW++o1xRNc0R+++g==",
-          "requires": {
-            "unist-util-is": "^3.0.0"
-          }
-        },
-        "unist-util-remove-position": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-1.1.4.tgz",
-          "integrity": "sha512-tLqd653ArxJIPnKII6LMZwH+mb5q+n/GtXQZo6S6csPRs5zB0u79Yw8ouR3wTw8wxvdJFhpP6Y7jorWdCgLO0A==",
-          "requires": {
-            "unist-util-visit": "^1.1.0"
-          }
-        },
-        "unist-util-stringify-position": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-1.1.2.tgz",
-          "integrity": "sha512-pNCVrk64LZv1kElr0N1wPiHEUoXNVFERp+mlTg/s9R5Lwg87f9bM/3sQB99w+N9D/qnM9ar3+AKDBwo/gm/iQQ=="
-        },
-        "unist-util-visit": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.1.tgz",
-          "integrity": "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==",
-          "requires": {
-            "unist-util-visit-parents": "^2.0.0"
-          }
-        },
-        "unist-util-visit-parents": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz",
-          "integrity": "sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==",
-          "requires": {
-            "unist-util-is": "^3.0.0"
-          }
-        },
-        "vfile": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/vfile/-/vfile-2.3.0.tgz",
-          "integrity": "sha512-ASt4mBUHcTpMKD/l5Q+WJXNtshlWxOogYyGYYrg4lt/vuRjC1EFQtlAofL5VmtVNIZJzWYFJjzGWZ0Gw8pzW1w==",
-          "requires": {
-            "is-buffer": "^1.1.4",
-            "replace-ext": "1.0.0",
-            "unist-util-stringify-position": "^1.0.0",
-            "vfile-message": "^1.0.0"
-          }
-        },
-        "vfile-location": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-2.0.6.tgz",
-          "integrity": "sha512-sSFdyCP3G6Ka0CEmN83A2YCMKIieHx0EDaj5IDP4g1pa5ZJ4FJDvpO0WODLxo4LUX4oe52gmSCK7Jw4SBghqxA=="
-        },
-        "vfile-message": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-1.1.1.tgz",
-          "integrity": "sha512-1WmsopSGhWt5laNir+633LszXvZ+Z/lxveBf6yhGsqnQIhlhzooZae7zV6YVM1Sdkw68dtAW3ow0pOdPANugvA==",
-          "requires": {
-            "unist-util-stringify-position": "^1.1.1"
-          }
-        }
-      }
     },
     "memory-fs": {
       "version": "0.4.1",
@@ -6152,14 +5849,6 @@
         "nprogress": "^0.2.0"
       }
     },
-    "no-case": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
-      "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
-      "requires": {
-        "lower-case": "^1.1.1"
-      }
-    },
     "node-emoji": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.10.0.tgz",
@@ -6450,14 +6139,6 @@
         "readable-stream": "^2.1.5"
       }
     },
-    "param-case": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/param-case/-/param-case-2.1.1.tgz",
-      "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
-      "requires": {
-        "no-case": "^2.2.0"
-      }
-    },
     "parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -6519,15 +6200,6 @@
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
       "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="
     },
-    "pascal-case": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-2.0.1.tgz",
-      "integrity": "sha1-LVeNNFX2YNpl7KGO+VtODekSdh4=",
-      "requires": {
-        "camel-case": "^3.0.0",
-        "upper-case-first": "^1.1.0"
-      }
-    },
     "pascalcase": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
@@ -6537,14 +6209,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.1.tgz",
       "integrity": "sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ=="
-    },
-    "path-case": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/path-case/-/path-case-2.1.1.tgz",
-      "integrity": "sha1-lLgDfDctP+KQbkZbtF4l0ibo7qU=",
-      "requires": {
-        "no-case": "^2.2.0"
-      }
     },
     "path-dirname": {
       "version": "1.0.2",
@@ -7638,16 +7302,6 @@
         "mdast-squeeze-paragraphs": "^4.0.0"
       }
     },
-    "remark-toc": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/remark-toc/-/remark-toc-7.0.0.tgz",
-      "integrity": "sha512-NyW/W7ttlj003eFXeIgq7eV2bffTQuO48PyC9zbh/RhTA/QaHJOAgJ4qvaRwKAVMWSBIh4W/5nZFWQ4rceV3fw==",
-      "dev": true,
-      "requires": {
-        "@types/unist": "^2.0.3",
-        "mdast-util-toc": "^5.0.0"
-      }
-    },
     "remarkable": {
       "version": "1.7.4",
       "resolved": "https://registry.npmjs.org/remarkable/-/remarkable-1.7.4.tgz",
@@ -7911,15 +7565,6 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
       "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
     },
-    "sentence-case": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-2.1.1.tgz",
-      "integrity": "sha1-H24t2jnBaL+S0T+G1KkYkz9mftQ=",
-      "requires": {
-        "no-case": "^2.2.0",
-        "upper-case-first": "^1.1.2"
-      }
-    },
     "serialize-javascript": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-3.1.0.tgz",
@@ -7980,14 +7625,6 @@
       "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
       "requires": {
         "is-arrayish": "^0.3.1"
-      }
-    },
-    "snake-case": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-2.1.0.tgz",
-      "integrity": "sha1-Qb2xtz8w7GagTU4srRt2OH1NbZ8=",
-      "requires": {
-        "no-case": "^2.2.0"
       }
     },
     "snapdragon": {
@@ -8482,15 +8119,6 @@
         "util.promisify": "~1.0.0"
       }
     },
-    "swap-case": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/swap-case/-/swap-case-1.1.2.tgz",
-      "integrity": "sha1-w5IDpFhzhfrTyFCgvRvK+ggZdOM=",
-      "requires": {
-        "lower-case": "^1.1.1",
-        "upper-case": "^1.1.1"
-      }
-    },
     "tailwindcss": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-1.6.0.tgz",
@@ -8687,15 +8315,6 @@
       "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
       "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q="
     },
-    "title-case": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/title-case/-/title-case-2.1.1.tgz",
-      "integrity": "sha1-PhJyFtpY0rxb7PE3q5Ha46fNj6o=",
-      "requires": {
-        "no-case": "^2.2.0",
-        "upper-case": "^1.0.3"
-      }
-    },
     "to-arraybuffer": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
@@ -8766,11 +8385,6 @@
       "requires": {
         "is-number": "^7.0.0"
       }
-    },
-    "to-style": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/to-style/-/to-style-1.3.3.tgz",
-      "integrity": "sha1-Y6K3Cm9KfU/cLtV6C+TnI1y2aZw="
     },
     "toml": {
       "version": "2.3.6",
@@ -9043,19 +8657,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
       "integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg=="
-    },
-    "upper-case": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
-      "integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg="
-    },
-    "upper-case-first": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-1.1.2.tgz",
-      "integrity": "sha1-XXm+3P8UQZUY/S7bCgUHybaFkRU=",
-      "requires": {
-        "upper-case": "^1.1.1"
-      }
     },
     "uri-js": {
       "version": "4.2.2",
@@ -9519,11 +9120,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
-    },
-    "x-is-string": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/x-is-string/-/x-is-string-0.1.0.tgz",
-      "integrity": "sha1-R0tQhlrzpJqcRlfwWs0UVFj3fYI="
     },
     "xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "gray-matter": "^4.0.2",
     "markdown-to-jsx": "^6.11.4",
     "markdown-toc": "^1.2.0",
-    "mdx-table-of-contents": "^0.1.0",
     "next": "^9.5.1",
     "next-mdx-remote": "^0.6.0",
     "nextjs-progressbar": "0.0.5",
@@ -38,7 +37,6 @@
     "js-yaml-loader": "^1.2.2",
     "parse-numeric-range": "^1.2.0",
     "react-kawaii": "^0.16.0",
-    "remark-toc": "^7.0.0",
     "tailwindcss": "^1.6.0"
   }
 }

--- a/src/components/NotePage.js
+++ b/src/components/NotePage.js
@@ -82,7 +82,7 @@ export default function NotePage({ mdxContent, frontMatter, toc }) {
           </div>
 
           <div sx={{ variant: "components.note.metaBlock" }}>
-            <Tags />
+            <Tags tags={frontMatter.tags} tech={frontMatter.tech} />
             <Share />
           </div>
 

--- a/src/components/NoteTemp/BackLinks.js
+++ b/src/components/NoteTemp/BackLinks.js
@@ -9,7 +9,7 @@ export default function BackLinks() {
         textAlign: "center",
         // mt: -4, // Use mt:-4, mb:4 if we have other bottomBlock content.
         display: "flex",
-        justifyContent: ["space-between", null, null, "flex-end"],
+        justifyContent: ["space-between", null, null, "flex-start"],
       }}
     >
       <a href="#main" sx={{ variant: "links.backToTop", pr: 2 }}>

--- a/src/components/NoteTemp/Tags.js
+++ b/src/components/NoteTemp/Tags.js
@@ -38,6 +38,7 @@ export default function Tags({ tags, tech }) {
               passHref
               prefetch={false}
             >
+              {/* <a sx={VARIANT}>{item}</a> */}
               <a sx={getTechSx(item)}>{item}</a>
             </Link>
           ))}

--- a/src/components/NoteTemp/Tags.js
+++ b/src/components/NoteTemp/Tags.js
@@ -1,24 +1,70 @@
 /** @jsx jsx */
-import { jsx, Styled } from "theme-ui";
+import { jsx } from "theme-ui";
+import Link from "next/link";
+import {
+  tags as tagsConfig,
+  tech as techConfig,
+} from "../../../taxonomies.yml";
 
-export default function Tags() {
+const VARIANT = { variant: "buttons.pill" };
+
+const getData = (name, source) => {
+  const hasData = Object.keys(source).includes(name);
+  return hasData ? source[name] : false;
+};
+
+const getTechSx = (name) => {
+  return {
+    ...VARIANT,
+    background: getData(name, techConfig).background || undefined,
+    color: getData(name, techConfig).color || undefined,
+  };
+};
+
+// = = =
+
+export default function Tags({ tags, tech }) {
+  if (!tags && !tech) return false;
+
   return (
     <div sx={{ variant: "components.note.tagsList" }}>
-      <a
-        sx={{
-          variant: "buttons.pill",
-          background: "#d43088",
-          color: "#fff",
-        }}
-        href="#"
-      >
-        graphql
-      </a>
-      {["learning notes", "some other tag"].map((tag) => (
-        <a key={tag} sx={{ variant: "buttons.pill" }} href="#">
-          {tag}
-        </a>
-      ))}
+      {tech ? (
+        <>
+          {tech.map((item) => (
+            <Link
+              key={item}
+              href="/notes/tags/[tag]"
+              as={`/notes/tags/${item}`}
+              passHref
+              prefetch={false}
+            >
+              <a sx={getTechSx(item)}>{item}</a>
+            </Link>
+          ))}
+        </>
+      ) : (
+        false
+      )}
+      {tags ? (
+        <>
+          {tags.map((item) => {
+            const tagLabel = getData(item, tagsConfig) ? getData(item, tagsConfig).label : item; // prettier-ignore
+            return (
+              <Link
+                key={item}
+                href="/notes/tags/[tag]"
+                as={`/notes/tags/${tagLabel}`}
+                passHref
+                prefetch={false}
+              >
+                <a sx={VARIANT}>{tagLabel}</a>
+              </Link>
+            );
+          })}
+        </>
+      ) : (
+        false
+      )}
     </div>
   );
 }

--- a/src/theme/variants/buttons.js
+++ b/src/theme/variants/buttons.js
@@ -19,17 +19,18 @@ const pill = {
   borderRadius: 32,
   backgroundColor: "muted",
   whiteSpace: "nowrap",
-  py: 1,
+  display: "inline-flex",
   px: 3,
+  py: 1,
   mr: 2,
   mb: 2,
   "&:hover,&:focus": {
-    backgroundColor: "primary",
     color: "background",
+    backgroundColor: "text",
   },
   "&.is-active": {
     color: "background",
-    backgroundColor: "text",
+    backgroundColor: "primary",
   },
   // Note: Set lineHeight from parent/extending component.
 };

--- a/src/theme/variants/note.js
+++ b/src/theme/variants/note.js
@@ -52,7 +52,7 @@ export default {
     alignItems: "center",
   },
   tagsList: {
-    lineHeight: getLhByFontIndex(3),
+    lineHeight: "1rem",
     mb: 8,
     maxWidth: "100%",
     a: { fontSize: "0.702rem" }, // heheheh

--- a/taxonomies.yml
+++ b/taxonomies.yml
@@ -1,7 +1,57 @@
+# used in CodeBlock
 lang:
   js:
-    background: "yellow"
+    background: "#f7e032"
     color: "black"
   graphql:
     background: "#e652ab"
-    color: "#fff"
+    color: "white"
+
+tags:
+  TIPS:
+    label: "console-logs"
+  LEARNING_NOTES:
+    label: "learning-notes"
+  RESOURCES:
+    label: "resources"
+
+tech:
+  javascript:
+    background: "#f7e032"
+    color: "black"
+  css:
+    background: "#264de4"
+    color: "white"
+  svelte:
+    background: "#ff3e00"
+    color: "white"
+  github:
+    background: "black"
+    color: "white"
+  nextjs:
+    background: "black"
+    color: "white"
+  mdx:
+    background: "#fcb42d"
+    color: "black"
+  graphql:
+    background: "#e652ab"
+    color: "white"
+  gatsby:
+    background: "#663399"
+    color: "white"
+  netlify:
+    background: "#164f78"
+    color: "white"
+  contentful:
+    background: "rgb(36, 120, 204)"
+    color: "white"
+  jamstack:
+    background: "#555"
+    color: "white"
+  laravel:
+    background: "#ff2d20"
+    color: "white"
+  php:
+    background: "#596a9c"
+    color: "white"


### PR DESCRIPTION
Render the content of `tags` and `tech` in Markdown frontmatter on single note page. Note that `tech` / `tag` distinction is *internal* in nature, ie. only for the Markdown frontmatter; both are simply different types of tag.

`tech` tags are displayed with their brand colours based on the YAML config.

All tags link to: `/notes/tags/${tagName}`.